### PR TITLE
fix #143 by setting LIB_INSTALL_DIR CMake var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include(CheckIncludeFiles)
 include(CheckTypeSize)
 include(CheckCCompilerFlag)
 include(TestBigEndian)
+include(GNUInstallDirs)
 
 check_function_exists(strndup HAVE_STRNDUP)
 check_function_exists(strnlen HAVE_STRNLEN)

--- a/evhtp.pc.in
+++ b/evhtp.pc.in
@@ -1,6 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@LIB_INSTALL_DIR@
-includedir=@INCLUDE_INSTALL_DIR@/evhtp
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/evhtp
 
 Name: libevhtp
 Description: A more flexible replacement for libevent's httpd API


### PR DESCRIPTION
This is a simple fix for #143 by reverting parts of 327bf14.
I don't know though whether this fits the intended modernized CMake workflow.