### PR TITLE
Fix mempcpy undefined error under macOs

### DIFF
--- a/examples/thread_design.c
+++ b/examples/thread_design.c
@@ -2,7 +2,7 @@
  * How to exploit the wonders of libevhtp's threading model to avoid using
  * libevent's locking API.
  *
- * In this example we use Redis's Async API (Libhiredis) store and retr the following
+ * In this example we use Redis's Async API (Libhiredis) store and retry the following
  * information for a request:
  *
  * Total requests seen.

--- a/include/internal.h
+++ b/include/internal.h
@@ -18,6 +18,10 @@ extern "C" {
 #       define evhtp_unlikely(x)       (x)
 #endif
 
+#ifndef mempcpy
+#       define mempcpy(...)  memcpy(__VA_ARGS__)
+#endif
+
 #ifndef TAILQ_FOREACH_SAFE
 #define TAILQ_FOREACH_SAFE(var, head, field, tvar)        \
     for ((var) = TAILQ_FIRST((head));                     \

--- a/include/internal.h
+++ b/include/internal.h
@@ -18,7 +18,7 @@ extern "C" {
 #       define evhtp_unlikely(x)       (x)
 #endif
 
-#ifndef mempcpy
+#if defined __APPLE__
 #       define mempcpy(...)  memcpy(__VA_ARGS__)
 #endif
 


### PR DESCRIPTION
```
[ 25%] Linking C executable example_https_server
Undefined symbols for architecture x86_64:
  "_mempcpy", referenced from:
      _htp__evbuffer_add_iovec_ in libevhtp.a(evhtp.c.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```