### PR TITLE
add evhtp_connection_ssl_new_dns

### DIFF
--- a/include/evhtp/evhtp.h
+++ b/include/evhtp/evhtp.h
@@ -1426,6 +1426,10 @@ evhtp_connection_new(struct event_base * evbase, const char * addr, uint16_t por
 EVHTP_EXPORT evhtp_connection_t * evhtp_connection_ssl_new(
     struct event_base * evbase,
     const char * addr, uint16_t port, evhtp_ssl_ctx_t * ctx);
+
+EVHTP_EXPORT evhtp_connection_t * evhtp_connection_ssl_new_dns(
+    struct event_base * evbase, struct evdns_base * dns_base,
+    const char * addr, uint16_t port, evhtp_ssl_ctx_t * ctx);
 #endif
 
 


### PR DESCRIPTION
example 
```
    const char* hostname = "www.gentoo.org";
    
    evhtp_connection_t* conn =
        evhtp_connection_ssl_new_dns(queue, dns, hostname, 443, ssl);

    // setup tls hos tname
    SSL_set_tlsext_host_name(conn->ssl, hostname);

    evhtp_request_t* req = evhtp_request_new(evhtp_callback, NULL);

    evhtp_headers_add_header(req->headers_out,
        evhtp_header_new("Host", hostname, NULL, NULL));

    evhtp_headers_add_header(req->headers_out,
            evhtp_header_new("Connection", "close", NULL, NULL));

    evhtp_make_request(conn, req, htp_method_GET, "/");
```
